### PR TITLE
Support both .scss and .sass extensions

### DIFF
--- a/webpack-sass-setup/src/index.html
+++ b/webpack-sass-setup/src/index.html
@@ -5,7 +5,11 @@
 </head>
 
 <body>
-    <div>Hello, world!</div>
+    <div id="container">
+        <span id="scss">A "Hello, world!" from .scss!</span>
+        <span id="sass">A "Hello, world!" from .sass!</span>
+    </div>
+
     <script src="<%= htmlWebpackPlugin.files.chunks.main.entry %>"></script>
 </body>
 

--- a/webpack-sass-setup/src/index.js
+++ b/webpack-sass-setup/src/index.js
@@ -1,2 +1,4 @@
 import './scss/main.scss';
+import './sass/main.sass';
+
 console.log('Hello, world!');

--- a/webpack-sass-setup/src/sass/main.sass
+++ b/webpack-sass-setup/src/sass/main.sass
@@ -1,0 +1,5 @@
+#sass
+    color: rgb(0, 0, 255)
+
+    &:hover
+        color: rgb(255, 0, 0)

--- a/webpack-sass-setup/src/scss/main.scss
+++ b/webpack-sass-setup/src/scss/main.scss
@@ -1,3 +1,12 @@
-div {
-  color: red;
+#container {
+  display: flex;
+  justify-content: space-around;
+
+  #scss {
+    color: red;
+
+    &:hover {
+      color: blue;
+    }
+  }
 }

--- a/webpack-sass-setup/webpack.config.js
+++ b/webpack-sass-setup/webpack.config.js
@@ -21,7 +21,7 @@ module.exports = {
         }
       },
       {
-        test: /\.scss$/,
+        test: /\.s[c|a]ss$/,
         use: ['style-loader', MiniCssExtractPlugin.loader, 'css-loader', 'postcss-loader', 'sass-loader']
       }
     ]


### PR DESCRIPTION
If no `?indentedSyntax` option is specified by the config, the `sass-loader` will infer its value by checking the extension to see if it's a `.sass` extension or not, so it's safe the apply the `sass-loader` to both the `.scss` and `.sass` extensions.

_I did not push any of the files in the `dist` directory so that there isn't a conflict with my other pull request that adds the `dist` directory as an ignored directory to the `.gitignore`_